### PR TITLE
Configurable path to the error log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 index.php
+
+# JetBrains IDEs
+.idea

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ $autoprefixer->compile($css_one, 'last 1 version');
 $autoprefixer->update();
 ```
 
+## Configuration
+
+You can set the path to the Autoprefixer error log using the const `AF_LOG_PATH`. By default,
+the log will be written to the file located at `sys_get_temp_dir() . '/autoprefixer.error.log'`.
+
 ## Speed
 On my Intel i5-3210M 2.5GHz and HDD 5200 RPM GitHub styles compiled in 390 ms.
 

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -65,10 +65,18 @@ class Autoprefixer
 			throw new AutoprefixerException($error_message);
 		}
 
+        // by default, use OS temp dir
+        $error_log_file_path = defined('AF_LOG_PATH') ? AF_LOG_PATH : (sys_get_temp_dir() . '/autoprefixer.error.log');
+
+        if (!is_writable($error_log_file_path)){
+            throw new AutoprefixerException("Error log file $error_log_file_path isn't writable");
+        }
+
 		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
-			array(array('pipe', 'r'), array('pipe', 'w'), array('file', '/tmp/autoprefixer.error.log', 'a')),
+			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file_path, 'a')),
 			$pipes
 		);
+
 		if ($nodejs === false) {
 			throw new RuntimeException('Could not reach node runtime');
 		}

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -65,15 +65,18 @@ class Autoprefixer
 			throw new AutoprefixerException($error_message);
 		}
 
-        // by default, use OS temp dir
-        $error_log_file_path = defined('AF_LOG_PATH') ? AF_LOG_PATH : (sys_get_temp_dir() . '/autoprefixer.error.log');
-
-        if (!is_writable($error_log_file_path)){
-            throw new AutoprefixerException("Error log file $error_log_file_path isn't writable");
-        }
+		// by default, use OS temp dir
+		$error_log_dir = defined('AF_LOG_DIR') ? AF_LOG_DIR : sys_get_temp_dir();
+		$error_log_file = $error_log_dir . DIRECTORY_SEPARATOR . 'autoprefixer.error.log';
+		if (!file_exists($error_log_file)) {
+			@touch($error_log_file);
+		}
+		if (!is_writable($error_log_file)){
+			throw new AutoprefixerException("Error log file '$error_log_file' isn't writable");
+		}
 
 		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
-			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file_path, 'a')),
+			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file, 'a')),
 			$pipes
 		);
 


### PR DESCRIPTION
You can set the path to the Autoprefixer error log using the const `AF_LOG_PATH`. By default, the log will be written to the file located at `sys_get_temp_dir() . '/autoprefixer.error.log'`.